### PR TITLE
Add API host config for frontend

### DIFF
--- a/frontend/blaster/src/api/boardApi.js
+++ b/frontend/blaster/src/api/boardApi.js
@@ -1,8 +1,7 @@
 import axios from 'axios';
 import jwtAxios from '../util/jwtUtil';
+import { API_SERVER_HOST } from './config';
 
-// const API_SERVER_HOST = 'https://native-pika-possibly.ngrok-free.app';
-const API_SERVER_HOST = 'http://localhost:8080';
 
 const postPrefix = `${API_SERVER_HOST}/api/post`;
 const commentPrefix = `${API_SERVER_HOST}/api/comment`;

--- a/frontend/blaster/src/api/config.js
+++ b/frontend/blaster/src/api/config.js
@@ -1,0 +1,2 @@
+export const API_SERVER_HOST =
+  process.env.REACT_APP_API_HOST || 'http://localhost:8080';

--- a/frontend/blaster/src/api/memberApi.js
+++ b/frontend/blaster/src/api/memberApi.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
 import jwtAxios from '../util/jwtUtil';
+import { API_SERVER_HOST } from './config';
 
-// export const API_SERVER_HOST = 'https://native-pika-possibly.ngrok-free.app';
-export const API_SERVER_HOST = 'http://localhost:8080';
+export { API_SERVER_HOST };
 
 const prefix = `${API_SERVER_HOST}/api/member`;
 

--- a/frontend/blaster/src/api/statsApi.js
+++ b/frontend/blaster/src/api/statsApi.js
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import jwtAxios from '../util/jwtUtil';
-
-// export const API_SERVER_HOST = 'https://native-pika-possibly.ngrok-free.app';
-export const API_SERVER_HOST = 'http://localhost:8080';
+import { API_SERVER_HOST } from './config';
 
 const prefix = `${API_SERVER_HOST}/api/game`;
 


### PR DESCRIPTION
## Summary
- add environment-based API host config
- import config in API modules

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686629048c00832c94fd86ea53ee64e4